### PR TITLE
Fix: Prevent unexpected EOF in workflow

### DIFF
--- a/.github/workflows/test-unblock.yaml
+++ b/.github/workflows/test-unblock.yaml
@@ -34,7 +34,9 @@ jobs:
         issue-number: ${{ fromJson(needs.detect-unblocked.outputs.matrix) }}
     steps:
       - name: Log Information
-        run: echo "Processing Unblocked Issue #${{ matrix.issue-number }}"
+        run: echo "Processing Unblocked Issue #$ISSUE_NUMBER"
+        env:
+          ISSUE_NUMBER: ${{ matrix.issue-number }}
 
       - name: Label as Ready
         uses: actions/github-script@v7


### PR DESCRIPTION
The `Log Information` step in the `process-unblocked-issues` job was failing with an "unexpected EOF" error. This was caused by the shell misinterpreting the `#` in the issue number as the start of a comment.

This commit fixes the issue by passing the issue number to the `echo` command using an environment variable. This ensures the issue number is treated as a string and prevents the shell from misinterpreting it.